### PR TITLE
Fix for missing a grid cell at longitudes close to min_lon

### DIFF
--- a/src/geodarn/gridding.py
+++ b/src/geodarn/gridding.py
@@ -88,7 +88,9 @@ def create_grid_records(located, lat_min=50, lat_width=1.0, hemisphere='north'):
         matching_points_lat = np.logical_and(lat < located.location[:, 1], located.location[:, 1] < lat + lat_width)
         matching_indices_lat = np.argwhere(matching_points_lat)
         lon_divs_for_lat = lon_divs[lat_idx[0]]
-        lon_indices = np.argwhere(np.logical_and(min_lon < lon_divs_for_lat, lon_divs_for_lat < max_lon))
+        lon_indices_temp = np.argwhere(np.logical_and(min_lon < lon_divs_for_lat, lon_divs_for_lat < max_lon))
+        if lon_indices_temp[0] != 0: # Just to be sure
+            lon_indices = np.append([lon_indices_temp[0].T-1], lon_indices_temp, axis=0)
 
         # Loop through the longitude bins with data
         for lon_idx in lon_indices:

--- a/src/geodarn/gridding.py
+++ b/src/geodarn/gridding.py
@@ -89,7 +89,7 @@ def create_grid_records(located, lat_min=50, lat_width=1.0, hemisphere='north'):
         matching_indices_lat = np.argwhere(matching_points_lat)
         lon_divs_for_lat = lon_divs[lat_idx[0]]
         lon_indices_temp = np.argwhere(np.logical_and(min_lon < lon_divs_for_lat, lon_divs_for_lat < max_lon))
-        if not lon_indices_temp:
+        if not lon_indices_temp.any():
             # For when min_lat and max_lat have too small of a delta to grid
             continue
         if lon_indices_temp[0] != 0: # Just to be sure

--- a/src/geodarn/gridding.py
+++ b/src/geodarn/gridding.py
@@ -89,6 +89,9 @@ def create_grid_records(located, lat_min=50, lat_width=1.0, hemisphere='north'):
         matching_indices_lat = np.argwhere(matching_points_lat)
         lon_divs_for_lat = lon_divs[lat_idx[0]]
         lon_indices_temp = np.argwhere(np.logical_and(min_lon < lon_divs_for_lat, lon_divs_for_lat < max_lon))
+        if not lon_indices_temp:
+            # For when min_lat and max_lat have too small of a delta to grid
+            continue
         if lon_indices_temp[0] != 0: # Just to be sure
             lon_indices = np.append([lon_indices_temp[0].T-1], lon_indices_temp, axis=0)
         if lon_indices_temp[-1] == len(lon_divs_for_lat) - 1:

--- a/src/geodarn/gridding.py
+++ b/src/geodarn/gridding.py
@@ -91,6 +91,8 @@ def create_grid_records(located, lat_min=50, lat_width=1.0, hemisphere='north'):
         lon_indices_temp = np.argwhere(np.logical_and(min_lon < lon_divs_for_lat, lon_divs_for_lat < max_lon))
         if lon_indices_temp[0] != 0: # Just to be sure
             lon_indices = np.append([lon_indices_temp[0].T-1], lon_indices_temp, axis=0)
+        if lon_indices_temp[-1] == len(lon_divs_for_lat) - 1:
+            lon_indices = lon_indices[0:-1]
 
         # Loop through the longitude bins with data
         for lon_idx in lon_indices:


### PR DESCRIPTION
This PR fixes a bug where longitudes that fell within a grid cell with a lower bound of `min_lon` were being excluded by a `where()` call. This fix ensures that grid cell is actually included. 